### PR TITLE
updating fstab to point to adobe sharepoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/folders/1LtNE0LBzCX3okGZwIMMxcs6Gp0emhPWy
+  /: https://adobe.sharepoint.com/:f:/r/sites/HelixProjects/Shared%20Documents/sites/merative


### PR DESCRIPTION
Still keeping the issue open until we point to Merative Sharepoint.

Test URLs:
- Before: https://main--merative--hlxsites.hlx.page/
- After: https://issue-3-update-fstab--merative--hlxsites.hlx.page/
