### PR TITLE
updating blog index definition to simplify tag names

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -60,10 +60,10 @@ indices:
         select: head > meta[name="category"]
         value: attribute(el, "content")
       audience:
-        select: head > meta[name="audience:tag"]
+        select: head > meta[name="audience"]
         value: attribute(el, "content")
       topic:
-        select: head > meta[name="topic:tag"]
+        select: head > meta[name="topic"]
         value: attribute(el, "content")
       author:
         select: head > meta[name="author"]


### PR DESCRIPTION

Fix #6 

Test URLs:
- Before: https://main--merative--hlxsites.hlx.page/
- After: https://issue-6-blog-index--merative--hlxsites.hlx.page/
