### PR TITLE
adding template property to blog index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -56,6 +56,9 @@ indices:
       date:
         select: head > meta[name="publication-date"]
         value: parseTimestamp(attribute(el, "content"), "MM/DD/YYYY")
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
       category:
         select: head > meta[name="category"]
         value: attribute(el, "content")


### PR DESCRIPTION
Need this for blog home / category pages and other functionality to identify which blog pages are category pages and which blog pages are articles.

Fix #6 

Test URLs:
- Before: https://main--merative--hlxsites.hlx.page/
- After: https://issue-6-blog-index--merative--hlxsites.hlx.page/
