### PR TITLE
getting placeholders from /blog/

### DIFF
--- a/blog/scripts/delayed.js
+++ b/blog/scripts/delayed.js
@@ -1,6 +1,6 @@
 import { sampleRUM, fetchPlaceholders } from './lib-franklin.js';
 
-const placeholders = await fetchPlaceholders();
+const placeholders = await fetchPlaceholders('blog');
 // const isProd = window.location.hostname.endsWith(placeholders.hostname);
 const productionLib = 'e5193f58fe47/launch-16c4e407bfc6';
 const previewLib = 'ccb695f49426/launch-f7e352870932-development';


### PR DESCRIPTION


Fix #69 

Test URLs:
- Before: https://main--merative--hlxsites.hlx.page/
- After: https://issue-69-cdn-stuff--merative--hlxsites.hlx.page/
