### PR TITLE
switching placeholders to /blog/placeholders

### DIFF
--- a/blog/scripts/delayed.js
+++ b/blog/scripts/delayed.js
@@ -1,6 +1,6 @@
 import { sampleRUM, fetchPlaceholders } from './lib-franklin.js';
 
-const placeholders = await fetchPlaceholders('blog');
+const placeholders = await fetchPlaceholders();
 // const isProd = window.location.hostname.endsWith(placeholders.hostname);
 const productionLib = 'e5193f58fe47/launch-16c4e407bfc6';
 const previewLib = 'ccb695f49426/launch-f7e352870932-development';

--- a/blog/scripts/lib-franklin.js
+++ b/blog/scripts/lib-franklin.js
@@ -158,7 +158,7 @@ export async function fetchPlaceholders(prefix = 'default') {
   if (!loaded) {
     window.placeholders[`${prefix}-loaded`] = new Promise((resolve, reject) => {
       try {
-        fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
+        fetch(`${prefix === 'default' ? '' : prefix}/blog/placeholders.json`)
           .then((resp) => resp.json())
           .then((json) => {
             const placeholders = {};


### PR DESCRIPTION
Fix #69 

Test URLs:
- Before: https://main--merative--hlxsites.hlx.page/blog
- After: https://issue-69-cdn-stuff--merative--hlxsites.hlx.page/blog
